### PR TITLE
quote for terraform11 syntax

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -291,6 +291,6 @@ variable "performance_insights_enabled" {
 
 variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance"
-  type        = string
+  type        = "string"
   default     = "rds-ca-2019"
 }


### PR DESCRIPTION
https://treasure-data.atlassian.net/browse/SRE-955

Okay, apparently we have to stop crying and actually test things.

It's currently failing at `terraform init` with:
```
Error downloading modules: Error loading modules: module db_plazmadb_primary: Error parsing .terraform/modules/dd13837e2ba26e3772b907de3cf05f49/variables.tf: At 294:17: Unknown token: 294:17 IDENT string:
```

Another terraform11/12 mannerism?

Anyways. I tested master and show that this hack will work if we merge it in..
```
jachin.hung@ip-10-10-0-147 cluster % git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   main.tf

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	init.tf

no changes added to commit (use "git add" and/or "git commit -a")
jachin.hung@ip-10-10-0-147 cluster % git diff
diff --git a/profiles/cluster/main.tf b/profiles/cluster/main.tf
index eb096c9..3626311 100644
--- a/profiles/cluster/main.tf
+++ b/profiles/cluster/main.tf
@@ -22,7 +22,8 @@ locals {

 // Create Plazmadb RDS Instance
 module "db_plazmadb_primary" {
-  source              = "github.com/rmkbow/terraform-aws-rds.git?ref=terraform011_classicrds"
+  #source              = "github.com/rmkbow/terraform-aws-rds.git?ref=terraform011_classicrds"
+  source = "github.com/td-jach/terraform-aws-rds.git?ref=terraform011_classicrds-add-quotes-sigh"
   snapshot_identifier = "${local.db_snapshot_identifier}"

   identifier = "${local.db_identifier}"
@@ -94,7 +95,8 @@ module "db_plazmadb_primary" {

 // create plazmadb replica
 module "db_plazmadb_replica" {
-  source = "github.com/rmkbow/terraform-aws-rds.git?ref=terraform011_classicrds"
+  # source = "github.com/rmkbow/terraform-aws-rds.git?ref=terraform011_classicrds"
+  source = "github.com/td-jach/terraform-aws-rds.git?ref=terraform011_classicrds-add-quotes-sigh"

   // storage should always be encrypted by default
   allocated_storage     = "${local.db_allocated_storage}"
jachin.hung@ip-10-10-0-147 cluster % terraform init
Initializing modules...
- module.data
- module.db_plazmadb_primary
- module.db_plazmadb_replica
- module.db_plazmadb_kms
- module.this_db_cloudwatch
- module.db_plazmadb_primary.db_subnet_group
- module.db_plazmadb_primary.db_parameter_group
- module.db_plazmadb_primary.db_option_group
- module.db_plazmadb_primary.db_instance
- module.db_plazmadb_replica.db_subnet_group
- module.db_plazmadb_replica.db_parameter_group
- module.db_plazmadb_replica.db_option_group
- module.db_plazmadb_replica.db_instance

Initializing the backend...

Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.51"

Terraform has been successfully initialized!
```